### PR TITLE
style: subtle nav underline, coral heart, neutral buttons

### DIFF
--- a/components/ActivityOfDay.tsx
+++ b/components/ActivityOfDay.tsx
@@ -17,7 +17,7 @@ export default function ActivityOfDay() {
         </button>
         <button
           type="button"
-          className="inline-flex items-center justify-center rounded-lg border border-coral text-coral px-4 py-2 text-sm font-medium hover:bg-coral-light hover:text-white transition focus:outline-none focus-visible:ring-2 focus-visible:ring-coral focus-visible:ring-offset-2 w-full sm:w-auto min-h-[44px]"
+          className="inline-flex items-center justify-center rounded-lg bg-neutral px-4 py-2 text-white text-sm font-medium hover:brightness-95 focus:outline-none focus-visible:ring-2 focus-visible:ring-coral focus-visible:ring-offset-2 transition w-full sm:w-auto min-h-[44px]"
         >
           Salvar no Planner
         </button>

--- a/components/BottomNav.tsx
+++ b/components/BottomNav.tsx
@@ -25,8 +25,8 @@ export default function BottomNav() {
                   className={[
                     "flex flex-col items-center justify-center rounded-xl px-3 py-2 text-xs sm:text-sm transition focus:outline-none focus-visible:ring-2 focus-visible:ring-coral focus-visible:ring-offset-2",
                     active
-                      ? "text-coral ring-1 ring-coral/30"
-                      : "text-neutral hover:bg-coral-light/20",
+                      ? "text-coral underline decoration-coral/60 underline-offset-4"
+                      : "text-neutral hover:bg-gray-100",
                   ].join(" ")}
                 >
                   <span aria-hidden className="text-base sm:text-lg leading-none">{it.icon}</span>


### PR DESCRIPTION
## Purpose
Visual-only refinements to improve palette coherence and elegance. The changes focus on creating a more subtle active navigation state, ensuring consistent coral theming for the heart icon, and standardizing secondary buttons with neutral styling.

## Code changes
- **BottomNav**: Replaced active item ring styling with subtle coral underline and updated hover states from coral-light to gray-100
- **ActivityOfDay**: Changed secondary button from coral border style to neutral background with white text and brightness hover effect

*Scope: Visual-only changes with no logic modifications.*To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 10`

🔗 [Edit in Builder.io](https://builder.io/app/projects/5b2d1241a5ad4c52a7aa8a06c6981415/glow-works)

👀 [Preview Link](https://5b2d1241a5ad4c52a7aa8a06c6981415-glow-works.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>5b2d1241a5ad4c52a7aa8a06c6981415</projectId>-->
<!--<branchName>glow-works</branchName>-->