### PR TITLE
Connect ActivityOfDay "Iniciar" button to Planner add flow

### DIFF
--- a/components/ActivityOfDay.tsx
+++ b/components/ActivityOfDay.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { DayKey, saveActivity } from "./Planner/PlannerStorage";
+import { openPlannerAdd } from "./planner/plannerBus";
 
 const DAY_ORDER: DayKey[] = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 const DAY_LABEL: Record<DayKey, string> = {
@@ -54,6 +55,7 @@ export default function ActivityOfDay() {
       <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-end">
         <button
           type="button"
+          onClick={openPlannerAdd}
           className="inline-flex items-center justify-center rounded-lg bg-coral px-4 py-2 text-sm font-medium text-white hover:bg-coral-hover active:bg-coral-active shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-coral focus-visible:ring-offset-2 transition w-full sm:w-auto min-h-[44px]"
         >
           Iniciar

--- a/components/planner/PlannerSection.tsx
+++ b/components/planner/PlannerSection.tsx
@@ -1,8 +1,9 @@
 "use client";
-import { useState, useMemo, useCallback } from "react";
+import { useState, useMemo, useCallback, useEffect, useRef } from "react";
 import { usePlanner } from "./usePlanner";
 import PlannerSheet from "./PlannerSheet";
 import PlannerList from "./PlannerList";
+import { onPlannerAdd } from "./plannerBus";
 
 function uid() {
   return "id-" + Math.random().toString(36).slice(2,10) + "-" + Date.now().toString(36);
@@ -11,6 +12,7 @@ function uid() {
 export default function PlannerSection() {
   const { items, addItem, toggleDone, loading } = usePlanner();
   const [open, setOpen] = useState(false);
+  const sectionRef = useRef<HTMLElement|null>(null);
 
   const onAddClick = useCallback(() => setOpen(true), []);
   const onSubmit = useCallback((input: {title:string; category:any; durationMin:number; notes?:string}) => {
@@ -29,8 +31,13 @@ export default function PlannerSection() {
   const empty = !items || items.length === 0;
   const top3 = useMemo(() => (items || []).slice(0,3), [items]);
 
+  useEffect(() => onPlannerAdd(() => {
+    sectionRef?.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    setOpen(true);
+  }), []);
+
   return (
-    <section className="bg-white rounded-2xl shadow-sm ring-1 ring-gray-200 p-6">
+    <section ref={sectionRef} className="bg-white rounded-2xl shadow-sm ring-1 ring-gray-200 p-6">
       <div className="flex items-start justify-between gap-4">
         <h2 className="text-lg sm:text-xl font-semibold text-gray-900">Planner</h2>
         <button onClick={onAddClick} className="rounded-lg bg-white ring-1 ring-gray-300 px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-50">Adicionar</button>

--- a/components/planner/plannerBus.ts
+++ b/components/planner/plannerBus.ts
@@ -1,0 +1,8 @@
+export const openPlannerAdd = () => {
+  document.dispatchEvent(new CustomEvent('planner:add'));
+};
+
+export const onPlannerAdd = (handler: () => void) => {
+  document.addEventListener('planner:add', handler);
+  return () => document.removeEventListener('planner:add', handler);
+};


### PR DESCRIPTION
## Purpose

Connect the "Iniciar" button in ActivityOfDay to trigger the same "Add activity" flow used by the Planner card, without changing any existing design. This creates a unified user experience where both entry points open the same PlannerSheet and focus the planner area.

## Code changes

- **Created global event bus** (`components/planner/plannerBus.ts`) with `openPlannerAdd()` and `onPlannerAdd()` functions to avoid prop drilling
- **Updated PlannerSection** to listen for planner add events, scroll into view, and open the sheet when triggered
- **Connected ActivityOfDay "Iniciar" button** to use `openPlannerAdd()` instead of previous handler
- **Added section ref** to PlannerSection for smooth scrolling behavior

The implementation maintains all existing styles and functionality while creating a seamless connection between the two components.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 17`

🔗 [Edit in Builder.io](https://builder.io/app/projects/5b2d1241a5ad4c52a7aa8a06c6981415/pulse-garden)

👀 [Preview Link](https://5b2d1241a5ad4c52a7aa8a06c6981415-pulse-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>5b2d1241a5ad4c52a7aa8a06c6981415</projectId>-->
<!--<branchName>pulse-garden</branchName>-->