### PR TITLE
Replace Link with button for notifications in header

### DIFF
--- a/components/shell/FixedHeader.tsx
+++ b/components/shell/FixedHeader.tsx
@@ -2,7 +2,6 @@
 
 import Brand from "../Brand";
 import { Bell } from "lucide-react";
-import Link from "next/link";
 
 export default function FixedHeader() {
   return (

--- a/components/shell/FixedHeader.tsx
+++ b/components/shell/FixedHeader.tsx
@@ -20,9 +20,9 @@ export default function FixedHeader() {
             </h1>
           </div>
           <div className="shrink-0">
-            <Link href="#" aria-label="Notificações" className="p-2 rounded-lg text-[color:var(--brand-navy)]/80 hover:bg-gray-50 focus:outline-none focus-visible:outline-2 focus-visible:outline-[color:var(--brand-coral)] focus-visible:outline-offset-2">
-              <Bell size={20} />
-            </Link>
+            <button type="button" aria-label="Notificações" className="p-2 rounded-lg text-[color:var(--brand-navy)]/80 hover:bg-gray-50 focus:outline-none focus-visible:outline-2 focus-visible:outline-[color:var(--brand-coral)] focus-visible:outline-offset-2">
+              <Bell size={20} aria-hidden="true" />
+            </button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Purpose
Clean up the Today page header by removing any stray or placeholder text and ensuring proper semantic HTML structure. The header should maintain its three-part layout: Materna360 logo on the left, "Today" section title in the center, and notifications icon on the right, without any unexpected text elements visible across all breakpoints.

## Code changes
- Replaced `Link` component with semantic `button` element for the notifications icon in the header
- Removed unused `Link` import from Next.js
- Added `aria-hidden="true"` attribute to the Bell icon for better accessibility
- Maintained all existing styling and focus states for the notifications button

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 38`

🔗 [Edit in Builder.io](https://builder.io/app/projects/5b2d1241a5ad4c52a7aa8a06c6981415/curry-zone)

👀 [Preview Link](https://5b2d1241a5ad4c52a7aa8a06c6981415-curry-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>5b2d1241a5ad4c52a7aa8a06c6981415</projectId>-->
<!--<branchName>curry-zone</branchName>-->