### PR TITLE
fix(build): remove ghost variant override to resolve Vercel build error

### DIFF
--- a/app/(tabs)/page.tsx
+++ b/app/(tabs)/page.tsx
@@ -103,7 +103,6 @@ export default function HomePage() {
             bodyClassName="text-[#333333]"
             primaryButtonClassName="bg-[color:var(--brand-coral)] text-white rounded-md px-3.5 py-2 font-semibold shadow-elev-1 hover:opacity-95 active:opacity-90 focus:outline-none focus:ring-2 focus:ring-[color:var(--brand-coral)]/40 focus:ring-offset-2"
             secondaryButtonClassName="ring-1 ring-[color:var(--brand-coral)] text-[color:var(--brand-navy)] rounded-md px-3.5 py-2 font-semibold hover:bg-white focus:outline-none focus:ring-2 focus:ring-[color:var(--brand-coral)]/40 focus:ring-offset-2"
-            secondaryButtonVariantOverride="ghost"
           />
         </Card>
 


### PR DESCRIPTION
## Purpose
Fix a Vercel build error by removing an unnecessary prop override that was causing build failures. The user identified that the `secondaryButtonVariantOverride="ghost"` prop was the source of the build issue and needed to be removed while preserving all other styling properties.

## Code changes
- Removed `secondaryButtonVariantOverride="ghost"` prop from the `<ActivityOfDay />` component in `app/(tabs)/page.tsx`
- Preserved existing `primaryButtonClassName` and `secondaryButtonClassName` props unchanged
- No other files or components were modified

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 41`

🔗 [Edit in Builder.io](https://builder.io/app/projects/5b2d1241a5ad4c52a7aa8a06c6981415/zenith-space)

👀 [Preview Link](https://5b2d1241a5ad4c52a7aa8a06c6981415-zenith-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>5b2d1241a5ad4c52a7aa8a06c6981415</projectId>-->
<!--<branchName>zenith-space</branchName>-->