### PR TITLE
Fix typos and improve UI visual design

### DIFF
--- a/app/cuidar/page.jsx
+++ b/app/cuidar/page.jsx
@@ -26,7 +26,7 @@ export default function Cuidar(){
       <h3 className="h3" style={{margin:"0 0 10px",fontWeight:800}}>Faça uma pausa</h3>
       <div className="grid-2">
         <NavyCard><div className="iconToken">◐</div><div>Respirar</div></NavyCard>
-        <NavyCard><div className="iconToken">🎵</div><div>Alegar</div></NavyCard>
+        <NavyCard><div className="iconToken">🎵</div><div>Alegrar</div></NavyCard>
       </div>
     </div>
   );

--- a/app/eu360/page.jsx
+++ b/app/eu360/page.jsx
@@ -9,8 +9,8 @@ export default function Eu360(){
       <h1 className="h1">Eu360</h1>
 
       <Card className="card-navy" style={{color:"#fff",background:"#0C1A2B",display:"grid",gridTemplateColumns:"140px 1fr",gap:18,alignItems:"center"}}>
-        <div className="ring" style={{"--p":"75%"}}>
-          <div>Circulo<br/>350</div>
+        <div className="ring" style={{"--p":"72%",background:"conic-gradient(#FF3B84 var(--p), rgba(255,255,255,.25) 0)"}}>
+          <div>Círculo<br/>350</div>
         </div>
         <div>
           <div style={{fontWeight:800,marginBottom:6}}>Você é importante</div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -14,7 +14,7 @@ main{min-height:100vh;display:flex;justify-content:center}
 .h1{font-family:Poppins,system-ui;font-weight:800;font-size:30px;letter-spacing:.2px;margin:0 0 8px}
 .sub{opacity:.8;margin:0 0 18px}
 .card{background:var(--white);border-radius:20px;padding:18px;box-shadow:0 14px 34px rgba(12,26,43,.08)}
-.card-navy{background:var(--navy);color:#fff;border-radius:20px;padding:18px;box-shadow:0 14px 34px rgba(12,26,43,.15)}
+.card-navy{background:var(--navy);color:#fff;border-radius:20px;padding:18px;box-shadow:0 10px 26px rgba(12,26,43,.12)}
 .btn{display:inline-block;border:0;border-radius:999px;padding:12px 16px;font-weight:800;background:var(--magenta);color:#fff;cursor:pointer}
 .btn-ghost{background:#fff;color:var(--magenta);border:1.5px solid var(--magenta)}
 .grid-2{display:grid;grid-template-columns:1fr 1fr;gap:16px}
@@ -32,12 +32,14 @@ main{min-height:100vh;display:flex;justify-content:center}
 .tab-active{position:relative}
 .tab-active::after{content:"";position:absolute;bottom:-6px;width:6px;height:6px;border-radius:50%;background:var(--magenta)}
 
+body{background: radial-gradient(1200px 700px at 50% -100px,#FBFCFF 0%,#F6F8FC 45%,#F3F5FA 100%);}
+
 /* Eu360 ring */
 .ring{--s:120px;position:relative;width:var(--s);height:var(--s);border-radius:50%;
   background:conic-gradient(var(--magenta) var(--p,40%), rgba(255,255,255,.2) 0);
   display:grid;place-items:center;outline:2px solid rgba(255,255,255,.25);outline-offset:-6px}
 .ring>div{width:calc(var(--s) - 18px);height:calc(var(--s) - 18px);border-radius:50%;
-  background:var(--navy);color:#fff;display:grid;place-items:center;font-weight:800}
+  background:#fff;color:var(--navy);display:grid;place-items:center;font-weight:800}
 
 /* Icon label inside navy cards */
 .iconStack{display:flex;flex-direction:column;gap:8px;align-items:center;justify-content:center;text-align:center}

--- a/app/page.jsx
+++ b/app/page.jsx
@@ -30,9 +30,9 @@ export default function Home(){
 
       <div className="grid-2">
         <NavyCard><div className="iconToken">◐</div><div>Respirar</div></NavyCard>
-        <NavyCard><div className="iconToken">♡</div><div>Refletir</div></NavyCard>
+        <Card style={{minHeight:110,display:"grid",placeItems:"center"}}><div className="iconStack"><div className="iconToken" style={{color:"var(--navy)",borderColor:"var(--navy)"}}>♡</div><div>Refletir</div></div></Card>
         <NavyCard><div className="iconToken">🔔</div><div>Inspirar</div></NavyCard>
-        <NavyCard><div className="iconToken">Ⅱ</div><div>Pausar</div></NavyCard>
+        <Card style={{minHeight:110,display:"grid",placeItems:"center"}}><div className="iconStack"><div className="iconToken" style={{color:"var(--navy)",borderColor:"var(--navy)"}}>Ⅱ</div><div>Pausar</div></div></Card>
       </div>
 
       <div className="space"></div>


### PR DESCRIPTION
## Purpose
The user requested several UI improvements to reduce visual heaviness and enhance the overall design. This includes fixing typos, updating color schemes with softer gradients, and converting some navy action cards to white cards for better visual balance.

## Code changes
- **Typography fixes**: Corrected "Alegar" to "Alegrar" in cuidar and page components, and "Circulo" to "Círculo" in eu360 page
- **Ring component updates**: Changed ring background to softer magenta gradient (#FF3B84) and updated inner ring to white background with navy text
- **Global styling improvements**: 
  - Reduced card-navy shadow intensity for lighter appearance
  - Added subtle radial gradient background to body
- **Component grid changes**: Converted "Refletir" and "Pausar" cards from NavyCard to white Card components with navy text styling

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 46`

🔗 [Edit in Builder.io](https://builder.io/app/projects/5b2d1241a5ad4c52a7aa8a06c6981415/zenith-zone)

👀 [Preview Link](https://5b2d1241a5ad4c52a7aa8a06c6981415-zenith-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>5b2d1241a5ad4c52a7aa8a06c6981415</projectId>-->
<!--<branchName>zenith-zone</branchName>-->