### PR TITLE
Add BottomTabBar component to root layout

### DIFF
--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -1,4 +1,5 @@
 import './globals.css';
+import BottomTabBar from '../components/BottomTabBar';
 
 export const metadata = {
   title: 'Materna360',
@@ -8,7 +9,12 @@ export const metadata = {
 export default function RootLayout({ children }) {
   return (
     <html lang="pt-BR">
-      <body>{children}</body>
+      <body>
+        <main>
+          {children}
+        </main>
+        <BottomTabBar />
+      </body>
     </html>
   );
 }


### PR DESCRIPTION
## Purpose
The user wanted to implement a fixed bottom navigation bar that appears on all pages of the Materna360 app. This provides consistent navigation throughout the application for better user experience.

## Code changes
- Import `BottomTabBar` component from `../components/BottomTabBar`
- Restructure the body content by wrapping children in a `<main>` element
- Add the `<BottomTabBar />` component at the bottom of the body to create a fixed navigation bar
- Updated the layout structure to support the new navigation component

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 51`

🔗 [Edit in Builder.io](https://builder.io/app/projects/5b2d1241a5ad4c52a7aa8a06c6981415/quantum-nest)

👀 [Preview Link](https://5b2d1241a5ad4c52a7aa8a06c6981415-quantum-nest.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>5b2d1241a5ad4c52a7aa8a06c6981415</projectId>-->
<!--<branchName>quantum-nest</branchName>-->