### PR TITLE
Add "use client" directive and remove metadata export

### DIFF
--- a/app/eu360/page.jsx
+++ b/app/eu360/page.jsx
@@ -1,7 +1,8 @@
+"use client";
+
 import Card from "../../components/ui/Card";
 import Btn from "../../components/ui/Btn";
 
-export const metadata={title:"Eu360 • Materna360"};
 
 export default function Eu360(){
   return (


### PR DESCRIPTION
## Purpose
Convert the Eu360 page component to a client-side component by adding the "use client" directive and removing the incompatible server-side metadata export, as requested by the user.

## Code changes
- Added `"use client";` directive at the top of the file
- Removed the `export const metadata` declaration that was causing compatibility issues with client components
- Added proper spacing for better code formatting

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 52`

🔗 [Edit in Builder.io](https://builder.io/app/projects/5b2d1241a5ad4c52a7aa8a06c6981415/nova-sanctuary)

👀 [Preview Link](https://5b2d1241a5ad4c52a7aa8a06c6981415-nova-sanctuary.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>5b2d1241a5ad4c52a7aa8a06c6981415</projectId>-->
<!--<branchName>nova-sanctuary</branchName>-->