### PR TITLE
Add AI-ready Ideas Generator and Showcase modal to descobrir

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -180,3 +180,26 @@ nav { background: var(--card); border-top: 1px solid var(--magenta-20); box-shad
 @media (min-width:768px){ .grid-activities, .grid-recs{ grid-template-columns: repeat(2, minmax(0,1fr)); } }
 
 .rec-actions{ display:flex; gap:10px; margin-top:10px; }
+
+/* chips */
+.chips-row{display:flex;gap:10px;flex-wrap:wrap;margin:12px 0}
+.chip{all:unset;cursor:pointer;padding:8px 14px;border-radius:999px;background:#fff;border:1.5px solid rgba(13,27,42,.12);color:#0D1B2A}
+.chip.is-active{border-color:#FF005E;box-shadow:0 8px 18px rgba(255,0,94,.12)}
+
+/* grids */
+.grid-ideas,.grid-recs{display:grid;gap:12px}
+@media(min-width:768px){.grid-ideas{grid-template-columns:repeat(2,minmax(0,1fr))}.grid-recs{grid-template-columns:repeat(3,minmax(0,1fr))}}
+.card.idea,.card.rec{background:#fff;border-radius:20px;padding:16px;box-shadow:0 12px 32px rgba(255,0,94,.06)}
+
+/* modal */
+.modal{display:none}
+.modal.is-open{display:block;position:fixed;inset:0;z-index:60}
+.modal .overlay{position:absolute;inset:0;background:rgba(0,0,0,.22);backdrop-filter:blur(8px)}
+.modal .modal-content{position:relative;z-index:1;margin:6vh auto;max-width:980px;background:#fff;border-radius:24px;padding:20px}
+.modal .modal-head{display:flex;align-items:center;justify-content:space-between;margin-bottom:12px}
+.modal .close{all:unset;cursor:pointer;font-size:28px;line-height:1;padding:6px}
+
+.thumb{width:100%;height:180px;object-fit:cover;border-radius:16px;margin-bottom:10px}
+.chip.subtle{background:#FFF6F8;border-color:#FFD3E3;color:#0D1B2A}
+
+/* keep existing .btn, .btn-primary, .btn-ghost styles */

--- a/lib/ideas.ts
+++ b/lib/ideas.ts
@@ -1,0 +1,40 @@
+export type Idea = { id: string; title: string; desc: string; duration?: string };
+
+const bank: Record<string, Record<string, Idea[]>> = {
+  "0-2": {
+    Casa: [
+      { id: "02c1", title: "Texturas mágicas", desc: "Monte um cesto com tecidos e esponjas para explorar sensações.", duration: "5–10 min" },
+      { id: "02c2", title: "Sons da casa", desc: "Descubram sons suaves com potes e colheres de silicone." },
+    ],
+    Parque: [{ id: "02p1", title: "Folhas e cores", desc: "Colete folhas e compare formatos, tamanhos e cores." }],
+    "Ar livre": [{ id: "02a1", title: "Bolhas de sabão", desc: "Estimule o olhar e a coordenação acompanhando bolhas." }],
+    Escola: [{ id: "02e1", title: "Roda de cantigas", desc: "Brinque com gestos simples em músicas curtas." }],
+  },
+  "3-4": {
+    Casa: [
+      { id: "34c1", title: "Dança livre", desc: "Escolha uma música calma e inventem movimentos." },
+      { id: "34c2", title: "Encaixar e empilhar", desc: "Use blocos/argolas para coordenação motora fina." },
+    ],
+    Parque: [{ id: "34p1", title: "Caça ao tesouro simples", desc: "Procure objetos por cor e forma no gramado." }],
+    "Ar livre": [{ id: "34a1", title: "Pintura com água", desc: "Pincéis + água para 'pintar' muros/chão." }],
+    Escola: [{ id: "34e1", title: "Histórias curtas", desc: "Livrinhos com figuras grandes e contrastes." }],
+  },
+  "5-7": {
+    Casa: [{ id: "57c1", title: "Teatro de fantoches", desc: "Criem personagens e uma mini-história." }],
+    Parque: [{ id: "57p1", title: "Corrida de formas", desc: "Desenhe estações no chão e cumpra desafios." }],
+    "Ar livre": [{ id: "57a1", title: "Desafio das sombras", desc: "Brinque de seguir e mudar sombras." }],
+    Escola: [{ id: "57e1", title: "Tangram simples", desc: "Monte figuras e conte a história delas." }],
+  },
+  "8+": {
+    Casa: [{ id: "8c1", title: "Chef júnior", desc: "Receita fria simples (iogurte com frutas)." }],
+    Parque: [{ id: "8p1", title: "Mapa do parque", desc: "Desenhe um mapa e esconda pistas." }],
+    "Ar livre": [{ id: "8a1", title: "Fotografia natureba", desc: "Caça a padrões de natureza com celular." }],
+    Escola: [{ id: "8e1", title: "Quadrinhos", desc: "Crie uma tirinha com começo, meio e fim." }],
+  },
+};
+
+export function generateIdeas(age: string, context: string): Idea[] {
+  const ctx = (bank as any)?.[age]?.[context] || [];
+  // Future: call AI here
+  return ctx.slice(0, 6);
+}

--- a/lib/recs.ts
+++ b/lib/recs.ts
@@ -1,0 +1,22 @@
+export type Product = { title: string; image: string; url: string; tag?: string; blurb?: string };
+
+export const productCatalog: Record<string, Record<string, Product[]>> = {
+  Livros: {
+    "0-2": [{ title: "Livro de tecido", image: "/images/books/tecido.jpg", url: "#", tag: "tato/sensações" }],
+    "3-4": [{ title: "Histórias em figuras", image: "/images/books/figuras.jpg", url: "#", tag: "curto e visual" }],
+    "5-7": [{ title: "Primeira aventura", image: "/images/books/aventura.jpg", url: "#" }],
+    "8+": [{ title: "Ciência divertida", image: "/images/books/ciencia.jpg", url: "#" }],
+  },
+  Brinquedos: {
+    "0-2": [{ title: "Chocalho macio", image: "/images/toys/chocalho.jpg", url: "#" }],
+    "3-4": [{ title: "Argolas de encaixe", image: "/images/toys/argolas.jpg", url: "#" }],
+    "5-7": [{ title: "Kit blocos criativos", image: "/images/toys/blocos.jpg", url: "#" }],
+    "8+": [{ title: "Quebra-cabeça 300pç", image: "/images/toys/puzzle.jpg", url: "#" }],
+  },
+  Cuidado: {
+    "0-2": [{ title: "Tapete de atividades", image: "/images/care/tapete.jpg", url: "#" }],
+    "3-4": [{ title: "Garrafa térmica kids", image: "/images/care/garrafa.jpg", url: "#" }],
+    "5-7": [{ title: "Capinha protetora", image: "/images/care/capinha.jpg", url: "#" }],
+    "8+": [{ title: "Lancheira", image: "/images/care/lancheira.jpg", url: "#" }],
+  },
+};

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -133,5 +133,24 @@ export function addGratitude(text) {
   return list;
 }
 
-// Re-export age group helpers from the JS storage module to support imports from "../../lib/storage"
-export { getLastAgeGroup, setLastAgeGroup } from "./storage.js";
+// Discover: persist last selections (SSR-safe try/catch)
+export function getLastAgeGroup(defaultVal = "3-4") {
+  try { return localStorage.getItem("m360.lastAge") || defaultVal } catch { return defaultVal }
+}
+export function setLastAgeGroup(v) {
+  try { localStorage.setItem("m360.lastAge", v) } catch {}
+}
+
+export function getLastContext(defaultVal = "Casa") {
+  try { return localStorage.getItem("m360.lastCtx") || defaultVal } catch { return defaultVal }
+}
+export function setLastContext(v) {
+  try { localStorage.setItem("m360.lastCtx", v) } catch {}
+}
+
+export function getLastRecCategory(defaultVal = "Livros") {
+  try { return localStorage.getItem("m360.lastRecCat") || defaultVal } catch { return defaultVal }
+}
+export function setLastRecCategory(v) {
+  try { localStorage.setItem("m360.lastRecCat", v) } catch {}
+}


### PR DESCRIPTION
## Purpose

Upgrade the `/descobrir` page to include:
- **AI-ready Ideas Generator**: Age + context selection that generates activity ideas
- **Neutral Showcase modal**: Product recommendations filtered by category and age
- Maintain the existing soft-luxury design aesthetic

## Code changes

### New library modules
- **`lib/storage.ts`**: Added localStorage persistence for `lastAgeGroup`, `lastContext`, and `lastRecCategory` with SSR-safe try/catch blocks
- **`lib/ideas.ts`**: Created stub `generateIdeas()` function with activity bank organized by age and context, ready for future AI integration
- **`lib/recs.ts`**: Added `productCatalog` with products grouped by category (Books, Toys, Care) and age ranges

### UI enhancements
- **Ideas Generator section**: Replaced simple age tabs with chip-based age/context selectors and "Generate Ideas" button
- **Showcase modal**: Added category chips and modal with product grid, hiding retailer names as requested
- **Styling**: Added CSS for chips, modal overlay, product thumbnails, and responsive grid layouts

### State management
- Added React state for context selection, generated ideas, category selection, and modal visibility
- Integrated localStorage functions to persist user selections across sessions

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 62`

🔗 [Edit in Builder.io](https://builder.io/app/projects/5b2d1241a5ad4c52a7aa8a06c6981415/nova-nest)

👀 [Preview Link](https://5b2d1241a5ad4c52a7aa8a06c6981415-nova-nest.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>5b2d1241a5ad4c52a7aa8a06c6981415</projectId>-->
<!--<branchName>nova-nest</branchName>-->