### PR TITLE
Refactor WeekProgress to dedicated component in Home grid

### DIFF
--- a/app/page.jsx
+++ b/app/page.jsx
@@ -11,38 +11,8 @@ import { addAction, addMood, toggleDayDone, getWeeklyPlan } from "../lib/storage
 import { emitEu360Refresh } from "../lib/clientEvents";
 import WeekChips from "../components/planner/WeekChips";
 import TipsRotator from "../components/planner/TipsRotator";
+import WeekProgress from "../components/planner/WeekProgress";
 
-function WeeklyPlannerAndTip(){
-  const [plan, setPlan] = useState(Array(7).fill(false));
-  const done = plan.filter(Boolean).length;
-
-  useEffect(()=>{ try{ setPlan(getWeeklyPlan()); }catch{} },[]);
-
-  function onToggle(i){
-    const p = toggleDayDone(i);
-    setPlan(p);
-    emitEu360Refresh();
-  }
-
-  return (
-    <section data-planner-root style={{marginTop:16}}>
-      <div style={{fontWeight:800,fontSize:18,color:"#0D1B2A", marginBottom:10, display:"flex", alignItems:"center", justifyContent:"space-between", gap:12}}>
-        <span>Planner da semana</span>
-        <span className="small" style={{opacity:.7}}>{done}/7 concluídos</span>
-      </div>
-      <WeekChips value={plan} onToggle={onToggle} />
-      <TipsRotator
-        tips={[
-          "Beba água e alongue-se 1 min.",
-          "Três respirações profundas.",
-          "Envie uma mensagem carinhosa pra você mesma.",
-          "Caminhe 2 min e olhe o céu."
-        ]}
-        key={done}
-      />
-    </section>
-  );
-}
 
 export default function Home(){
   const [openBreath, setOpenBreath] = useState(false);
@@ -80,11 +50,9 @@ export default function Home(){
         <Card style={{minHeight:110,display:"grid",placeItems:"center"}} onClick={() => setOpenMood(true)}><div className="iconStack"><div className="iconToken">♡</div><div>Refletir</div></div></Card>
         <NavyCard onClick={() => setOpenInspire(true)}><div className="iconToken">🔔</div><div>Inspirar</div></NavyCard>
         <Card style={{minHeight:110,display:"grid",placeItems:"center"}} onClick={() => setOpenPause(true)}><div className="iconStack"><div className="iconToken">Ⅱ</div><div>Pausar</div></div></Card>
+        <WeekProgress />
       </div>
 
-      <div className="space"></div>
-
-      <WeeklyPlannerAndTip />
 
       <BreathModal
         open={openBreath}

--- a/components/planner/WeekProgress.jsx
+++ b/components/planner/WeekProgress.jsx
@@ -1,0 +1,41 @@
+"use client";
+import { useEffect, useState } from "react";
+import Card from "../ui/Card";
+import WeekChips from "./WeekChips";
+import TipsRotator from "./TipsRotator";
+import { getWeeklyPlan, toggleDayDone } from "../../lib/storage";
+import { emitEu360Refresh } from "../../lib/clientEvents";
+
+export default function WeekProgress(){
+  const [plan, setPlan] = useState(Array(7).fill(false));
+  const done = Array.isArray(plan) ? plan.filter(Boolean).length : 0;
+
+  useEffect(()=>{ try{ setPlan(getWeeklyPlan()); }catch{} },[]);
+
+  function onToggle(i){
+    try {
+      const p = toggleDayDone(i);
+      setPlan(p);
+      emitEu360Refresh();
+    } catch {}
+  }
+
+  return (
+    <Card>
+      <div style={{fontWeight:800,fontSize:18,color:"#0D1B2A", marginBottom:10, display:"flex", alignItems:"center", justifyContent:"space-between", gap:12}}>
+        <span>Planner da semana</span>
+        <span className="small" style={{opacity:.7}}>{done}/7 concluídos</span>
+      </div>
+      <WeekChips value={plan} onToggle={onToggle} />
+      <TipsRotator
+        tips={[
+          "Beba água e alongue-se 1 min.",
+          "Três respirações profundas.",
+          "Envie uma mensagem carinhosa pra você mesma.",
+          "Caminhe 2 min e olhe o céu."
+        ]}
+        key={done}
+      />
+    </Card>
+  );
+}


### PR DESCRIPTION
## Purpose

Remove duplicate WeekProgress implementation in Home page and consolidate into a single reusable component. The goal is to eliminate code duplication while maintaining the exact same layout and styling, placing the WeekProgress card within the Home actions grid alongside other quick actions.

## Code changes

- **Removed** local `WeeklyPlannerAndTip` function from `app/page.jsx` (38 lines)
- **Created** new `components/planner/WeekProgress.jsx` component with improved error handling
- **Added** WeekProgress import to Home page
- **Moved** WeekProgress placement into the actions grid after the four quick action cards
- **Wrapped** component content in Card component to maintain consistent styling
- **Enhanced** error handling with try-catch blocks around storage operations

The WeekProgress component now renders as a card within the Home grid layout, preserving the soft-luxury spacing and visual consistency while eliminating duplicate code.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 68`

🔗 [Edit in Builder.io](https://builder.io/app/projects/5b2d1241a5ad4c52a7aa8a06c6981415/echo-home)

👀 [Preview Link](https://5b2d1241a5ad4c52a7aa8a06c6981415-echo-home.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>5b2d1241a5ad4c52a7aa8a06c6981415</projectId>-->
<!--<branchName>echo-home</branchName>-->