### PR TITLE
Add useReminders hook for breathe and gratitude notifications

### DIFF
--- a/hooks/useReminders.js
+++ b/hooks/useReminders.js
@@ -1,0 +1,66 @@
+'use client';
+import { useEffect, useRef, useState, useCallback } from 'react';
+import { get, set, keys, onUpdate } from '../lib/storage';
+
+const DEFAULTS = {
+  breathe:   { on: true,  everyMin: 180 },
+  gratitude: { on: true,  at: ['20:00'] },
+};
+
+function readPrefs(){ return { ...DEFAULTS, ...(get(keys.reminders, {})||{}) }; }
+function savePrefs(p){ set(keys.reminders, p); return p; }
+function readLast(){ return get(keys.lastSeen, {}) || {}; }
+function writeLast(v){ set(keys.lastSeen, v); }
+
+function nowHM(){
+  const d = new Date();
+  return `${String(d.getHours()).padStart(2,'0')}:${String(d.getMinutes()).padStart(2,'0')}`;
+}
+
+export default function useReminders(){
+  const [prefs, setPrefs] = useState(readPrefs);
+  const [last, setLast] = useState(readLast);
+  const timers = useRef([]);
+
+  const update = useCallback((next) => { setPrefs(savePrefs(next)); }, []);
+  const setBreatheEvery = useCallback((min) => update({ ...prefs, breathe:{...prefs.breathe, everyMin: min, on:true} }), [prefs, update]);
+  const setGratitudeAt = useCallback((times) => update({ ...prefs, gratitude:{...prefs.gratitude, at: times, on:true} }), [prefs, update]);
+  const toggle = useCallback((key, on) => update({ ...prefs, [key]:{...prefs[key], on} }), [prefs, update]);
+
+  useEffect(() => {
+    timers.current.forEach(clearTimeout); timers.current = [];
+    if (typeof window === 'undefined') return;
+
+    if (prefs.breathe?.on && prefs.breathe.everyMin > 0) {
+      const ms = prefs.breathe.everyMin * 60 * 1000;
+      const tick = () => {
+        window.dispatchEvent(new CustomEvent('m360:reminder', { detail:{ type:'breathe' } }));
+        timers.current.push(setTimeout(tick, ms));
+      };
+      timers.current.push(setTimeout(tick, ms));
+    }
+
+    if (prefs.gratitude?.on && Array.isArray(prefs.gratitude.at)) {
+      const check = () => {
+        const hm = nowHM();
+        if (prefs.gratitude.at.includes(hm)) {
+          const mem = readLast();
+          const dayKey = new Date().toISOString().slice(0,10);
+          const stampKey = `${dayKey}:${hm}`;
+          if (mem.gratitude !== stampKey) {
+            window.dispatchEvent(new CustomEvent('m360:reminder', { detail:{ type:'gratitude' } }));
+            mem.gratitude = stampKey; writeLast(mem); setLast(mem);
+          }
+        }
+        timers.current.push(setTimeout(check, 60*1000));
+      };
+      timers.current.push(setTimeout(check, 5*1000));
+    }
+
+    return () => { timers.current.forEach(clearTimeout); timers.current = []; };
+  }, [prefs]);
+
+  useEffect(() => onUpdate((key)=>{ if (key===keys.reminders||key===keys.lastSeen) { setPrefs(readPrefs()); setLast(readLast()); } }), []);
+
+  return { prefs, last, update, setBreatheEvery, setGratitudeAt, toggle };
+}

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -271,6 +271,8 @@ export const keys = {
   inspireIndex: `${NS}inspireIndex`,
   recProductsCategory: `${NS}recProductsCategory`,
   lastCtx: `${NS}lastCtx`,
+  reminders: `${NS}reminders`,
+  lastSeen: `${NS}reminders:lastSeen`,
 };
 
 export function get(key, fallback = null) {
@@ -337,5 +339,7 @@ export function getAll() {
     inspireIndex: get(keys.inspireIndex, 0),
     recProductsCategory: get(keys.recProductsCategory, ''),
     lastCtx: get(keys.lastCtx, null),
+    reminders: get(keys.reminders, {}),
+    lastSeen: get(keys.lastSeen, {}),
   };
 }


### PR DESCRIPTION
## Purpose

The user wanted to implement a reminder system for wellness activities, specifically breathing exercises and gratitude practice. The goal was to create a configurable notification system that can trigger reminders at regular intervals (for breathing) and at specific times (for gratitude), with the ability to track when reminders were last shown to avoid duplicates.

## Code changes

- **Added `useReminders` hook** (`hooks/useReminders.js`):
  - Implements configurable reminder preferences with defaults (breathe every 3 hours, gratitude at 8 PM)
  - Manages timer-based notifications using `setTimeout` for both interval and scheduled reminders
  - Dispatches custom events (`m360:reminder`) when reminders trigger
  - Tracks last seen reminders to prevent duplicate notifications on the same day
  - Provides methods to update preferences: `setBreatheEvery`, `setGratitudeAt`, and `toggle`
  - Handles cleanup of timers and storage synchronization

- **Extended storage system** (`lib/storage.js`):
  - Added `reminders` and `lastSeen` keys to the storage namespace
  - Updated `getAll()` function to include the new reminder-related storage keys

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 86`

🔗 [Edit in Builder.io](https://builder.io/app/projects/5b2d1241a5ad4c52a7aa8a06c6981415/pulse-landing)

👀 [Preview Link](https://5b2d1241a5ad4c52a7aa8a06c6981415-pulse-landing.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>5b2d1241a5ad4c52a7aa8a06c6981415</projectId>-->
<!--<branchName>pulse-landing</branchName>-->