### PR TITLE
Rename dynamic import to avoid naming collision

### DIFF
--- a/app/descobrir/page.jsx
+++ b/app/descobrir/page.jsx
@@ -10,7 +10,7 @@ import { getLastAgeGroup, setLastAgeGroup, getLastContext, setLastContext, getLa
 import { generateIdeas } from "../../lib/ideas";
 import { productCatalog } from "../../lib/recs";
 
-const Vitrine = dynamic(() => import("../../components/discover/Vitrine"), { ssr: false });
+const Vitrine = NextDynamic(() => import("../../components/discover/Vitrine"), { ssr: false });
 
 export default function Descobrir(){
   const ages = ["0-2","3-4","5-7","8+"];

--- a/app/descobrir/page.jsx
+++ b/app/descobrir/page.jsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import dynamic from "next/dynamic";
+import NextDynamic from "next/dynamic";
 import Card from "../../components/ui/Card";
 import NavyCard from "../../components/ui/NavyCard";
 import Btn from "../../components/ui/Btn";


### PR DESCRIPTION
## Purpose
Fix naming collision between Next.js dynamic import and the `dynamic` export constant by renaming the import to avoid conflicts and ensure proper functionality.

## Code changes
- Renamed `dynamic` import from `next/dynamic` to `NextDynamic` in `app/descobrir/page.jsx`
- Updated the corresponding usage of the dynamic import function to use the new `NextDynamic` name
- This prevents potential conflicts with other variables or exports named `dynamic` in the codebase

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 89`

🔗 [Edit in Builder.io](https://builder.io/app/projects/5b2d1241a5ad4c52a7aa8a06c6981415/orbit-lab-1)

👀 [Preview Link](https://5b2d1241a5ad4c52a7aa8a06c6981415-orbit-lab-1.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>5b2d1241a5ad4c52a7aa8a06c6981415</projectId>-->
<!--<branchName>orbit-lab-1</branchName>-->