### PR TITLE
Add RemindersPanel component with breathing and gratitude settings

### DIFF
--- a/components/RemindersPanel.jsx
+++ b/components/RemindersPanel.jsx
@@ -1,0 +1,125 @@
+'use client';
+import { useEffect, useMemo, useState } from 'react';
+import { get, set, keys } from '../lib/storage';
+import { showToast } from '../lib/ui/toast';
+import styles from './RemindersPanel.module.css';
+
+const DEFAULTS = {
+  breathe:   { on: true, everyMin: 180 },     // 3h
+  gratitude: { on: true, at: ['20:00'] },     // 20:00
+};
+
+function normalizePrefs(p) {
+  const base = { ...DEFAULTS, ...(p || {}) };
+  const em = Number(base.breathe?.everyMin) || DEFAULTS.breathe.everyMin;
+  base.breathe = { on: !!base.breathe?.on, everyMin: Math.max(1, em) };
+  const times = Array.isArray(base.gratitude?.at) ? base.gratitude.at : DEFAULTS.gratitude.at;
+  const clean = times
+    .map(String)
+    .map((t) => t.trim())
+    .filter(Boolean)
+    .map((t) => (t.match(/^\d{2}:\d{2}$/) ? t : null))
+    .filter(Boolean);
+  base.gratitude = { on: !!base.gratitude?.on, at: clean.length ? clean : DEFAULTS.gratitude.at };
+  return base;
+}
+
+export default function RemindersPanel() {
+  const [prefs, setPrefs] = useState(() => normalizePrefs(get(keys.reminders, DEFAULTS)));
+  const [dirty, setDirty] = useState(false);
+  const timesText = useMemo(() => (prefs.gratitude.at || []).join(', '), [prefs]);
+
+  useEffect(() => {
+    setPrefs(normalizePrefs(get(keys.reminders, DEFAULTS)));
+  }, []);
+
+  function save() {
+    const finalPrefs = normalizePrefs(prefs);
+    set(keys.reminders, finalPrefs);
+    setDirty(false);
+    showToast('Lembretes salvos — Suas preferências foram atualizadas 💛');
+  }
+
+  function parseTimes(s) {
+    const list = String(s || '')
+      .split(',')
+      .map((x) => x.trim())
+      .filter(Boolean);
+    setPrefs((p) => normalizePrefs({ ...p, gratitude: { ...p.gratitude, at: list } }));
+    setDirty(true);
+  }
+
+  return (
+    <div className={styles.panelContainer}>
+      <h3 className={styles.panelTitle}>Lembretes</h3>
+
+      <div className={styles.rowToggle}>
+        <label className={styles.labelStrong}>Respirar</label>
+        <label className={styles.toggleLabel}>
+          <input
+            type="checkbox"
+            checked={!!prefs.breathe.on}
+            onChange={(e) => {
+              setPrefs((p) => ({ ...p, breathe: { ...p.breathe, on: e.target.checked } }));
+              setDirty(true);
+            }}
+          />
+          <span className={styles.toggleHelp}>Ativo</span>
+        </label>
+      </div>
+
+      <div className={styles.rowInput}>
+        <div className={styles.hintText}>Intervalo (minutos) — ex.: 180 para a cada 3h</div>
+        <input
+          className={styles.numberInput}
+          type="number"
+          min={1}
+          value={prefs.breathe.everyMin}
+          onChange={(e) => {
+            setPrefs((p) => ({ ...p, breathe: { ...p.breathe, everyMin: Number(e.target.value || 1) } }));
+            setDirty(true);
+          }}
+        />
+      </div>
+
+      <div className={styles.rowToggle}>
+        <label className={styles.labelStrong}>Gratidão</label>
+        <label className={styles.toggleLabel}>
+          <input
+            type="checkbox"
+            checked={!!prefs.gratitude.on}
+            onChange={(e) => {
+              setPrefs((p) => ({ ...p, gratitude: { ...p.gratitude, on: e.target.checked } }));
+              setDirty(true);
+            }}
+          />
+          <span className={styles.toggleHelp}>Ativo</span>
+        </label>
+      </div>
+
+      <div className={styles.hintText}>Horários (HH:MM), separados por vírgula — ex.: 12:00, 20:00</div>
+      <input
+        className={styles.textInput}
+        type="text"
+        defaultValue={timesText}
+        placeholder="20:00"
+        onBlur={(e) => parseTimes(e.target.value)}
+      />
+
+      <div className={styles.actionsRow}>
+        <button
+          className={styles.resetButton}
+          onClick={() => {
+            setPrefs(normalizePrefs(get(keys.reminders, DEFAULTS)));
+            setDirty(false);
+          }}
+        >
+          Desfazer
+        </button>
+        <button className={styles.saveButton} onClick={save} disabled={!dirty}>
+          Salvar
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/RemindersPanel.module.css
+++ b/components/RemindersPanel.module.css
@@ -1,0 +1,84 @@
+.panelContainer {
+  border: 1px solid #eee;
+  border-radius: 16px;
+  padding: 16px;
+  background: #fff;
+  max-width: 620px;
+}
+
+.panelTitle {
+  margin: 0 0 12px 0;
+}
+
+.rowToggle {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 12px;
+  align-items: center;
+  margin-bottom: 14px;
+}
+
+.labelStrong {
+  font-weight: 600;
+}
+
+.toggleLabel {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.toggleHelp {
+  opacity: 0.8;
+}
+
+.rowInput {
+  display: grid;
+  grid-template-columns: 1fr 120px;
+  gap: 12px;
+  align-items: center;
+  margin-bottom: 22px;
+}
+
+.hintText {
+  opacity: 0.9;
+}
+
+.numberInput {
+  padding: 8px 10px;
+  border: 1px solid #ddd;
+  border-radius: 10px;
+}
+
+.textInput {
+  width: 100%;
+  padding: 8px 10px;
+  border: 1px solid #ddd;
+  border-radius: 10px;
+  margin-bottom: 20px;
+}
+
+.actionsRow {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+}
+
+.resetButton {
+  padding: 10px 14px;
+  border-radius: 10px;
+  border: 1px solid #ddd;
+  background: #fafafa;
+}
+
+.saveButton {
+  padding: 10px 14px;
+  border-radius: 10px;
+  border: none;
+  background: #0D1B2A;
+  color: #fff;
+}
+
+.saveButton:disabled {
+  background: #888;
+}


### PR DESCRIPTION
## Purpose

The user wanted to create a settings panel for managing reminder preferences, specifically for breathing exercises and gratitude practices. The component needed to handle user preferences with proper validation, persistence, and a clean UI for configuring reminder intervals and schedules.

## Code changes

- **Added `RemindersPanel.jsx`**: New React component with state management for reminder preferences
  - Implements breathing reminder settings (on/off toggle + interval in minutes)
  - Implements gratitude reminder settings (on/off toggle + time schedule input)
  - Includes preference normalization and validation logic
  - Provides save/reset functionality with dirty state tracking
  - Uses local storage for persistence via storage utility
  - Shows toast notifications on save

- **Added `RemindersPanel.module.css`**: Comprehensive styling for the panel
  - Grid-based layout for form rows and controls
  - Styled inputs, buttons, and toggles
  - Responsive design with max-width constraint
  - Clean visual hierarchy with proper spacing and typography

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 90`

🔗 [Edit in Builder.io](https://builder.io/app/projects/5b2d1241a5ad4c52a7aa8a06c6981415/aura-haven)

👀 [Preview Link](https://5b2d1241a5ad4c52a7aa8a06c6981415-aura-haven.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>5b2d1241a5ad4c52a7aa8a06c6981415</projectId>-->
<!--<branchName>aura-haven</branchName>-->